### PR TITLE
review fix for code block formatting issue (#33)

### DIFF
--- a/delta/base.py
+++ b/delta/base.py
@@ -284,9 +284,13 @@ class Delta(object):
                 is_previous_newline = False
             else:
                 attributes = iter.next(1).get('attributes', {})
-                yield line, attributes, i
+                if not line and attributes.get('code-block'):
+                    # Code block's <pre> html tag handles newline characters automatically
+                    yield Delta([{'insert': '\n'}]), attributes, i
+                else:
+                    yield line, attributes, i
                 i += 1
-                if is_previous_newline:
+                if is_previous_newline and not attributes.get('code-block'):
                     yield Delta([{'insert': ''}]), attributes, i  # adds <br> tag
                     i += 1
                 line = Delta()

--- a/delta/html.py
+++ b/delta/html.py
@@ -52,8 +52,8 @@ def sub_element(root, *a, **kwargs):
 def styled(element, styles):
     if element.tag != 'span':
         element = sub_element(element, 'span')
-    declare = parseStyle(element.attrib.get('style', ''))
     try:
+        declare = parseStyle(element.attrib.get('style', ''))
         for k, v in styles.items():
             declare.setProperty(k, v)
         element.attrib['style'] = declare.getCssText(' ')
@@ -228,16 +228,18 @@ def font(root, op):
 def link(root, op):
     if type(op['attributes']['link']) is dict:
         el = sub_element(root, 'a')
-        allowed_attrs = ['href', 'target']
-        for key in allowed_attrs:
-            value = op['attributes']['link'].get(key)
-            if value or type(value) is int:
-                el.attrib[key] = value
-                if key == 'target' and value == '_blank':
-                    el.attrib['rel'] = 'noopener'
+        href = op['attributes']['link'].get('href')
+        target = op['attributes']['link'].get('target')
+        el.attrib['href'] = href
+        # # No target linking for javascript links
+        if target and not href.startswith('javascript:'):
+            el.attrib['target'] = target
+            if target == '_blank':
+                el.attrib['rel'] = 'noopener'
     else:
         el = sub_element(root, 'a')
         el.attrib['href'] = op['attributes']['link']
+
     return el
 
 
@@ -621,7 +623,7 @@ def blockquote(block, attrs):
 def code_block(root, op):
     root.tag = 'pre'
     root.attrib.update({
-        'class': CODE_BLOCK_CLASS
+        'class': root.attrib.get('class', '') + ' ' + CODE_BLOCK_CLASS
     })
     return root
 


### PR DESCRIPTION
* Moved cssparser call into try...except clause to mute CSS warnings

* Disabled delta-py target attribute in links when the link is a javascript link

* handled a case where code block was getting incomplete classes and formatting

* handled code blocks with edge cases

Co-authored-by: stevenmoseley <smoseley@transio.com>
Co-authored-by: Steven Moseley <steve@unstack.com>